### PR TITLE
Allow function as "parentTag" property

### DIFF
--- a/lib/doc.js
+++ b/lib/doc.js
@@ -81,7 +81,11 @@ Doc.prototype.applyFormat = function(node, format, value) {
   }
 
   if (format.parentTag) {
-    var parent = this.document.createElement(format.parentTag);
+    var parentTag = format.parentTag;
+    if (typeof parentTag === 'function') {
+      parentTag = parentTag(node, value, dom);
+    }
+    var parent = this.document.createElement(parentTag);
     dom(node).wrap(parent);
     if (parent.previousSibling && parent.tagName === parent.previousSibling.tagName) {
       dom(parent.previousSibling).merge(parent);


### PR DESCRIPTION
This enables advanced functionality where the parent tag depends on the value of an attribute, e.g. lists